### PR TITLE
Added Consumer KYC Api integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.5
+- Added KYC Consumer integration
+
 # 0.2.4
 - Add az to limited length params
 

--- a/identity_mind.gemspec
+++ b/identity_mind.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'httparty', '~>0.16'
+  spec.add_dependency 'httparty', '~>0.14'
 end

--- a/lib/identity_mind/account.rb
+++ b/lib/identity_mind/account.rb
@@ -1,5 +1,6 @@
 module IdentityMind
   module Account
     class Merchant < Entity; end
+    class Consumer < Entity; end
   end
 end

--- a/lib/identity_mind/version.rb
+++ b/lib/identity_mind/version.rb
@@ -1,3 +1,3 @@
 module IdentityMind
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.5'.freeze
 end

--- a/spec/identity_mind/account/consumer_spec.rb
+++ b/spec/identity_mind/account/consumer_spec.rb
@@ -1,0 +1,12 @@
+require 'ostruct'
+
+RSpec.describe IdentityMind::Account::Consumer do
+  it 'has Entity superclass' do
+    expect(described_class.superclass)
+      .to eq(IdentityMind::Entity)
+  end
+
+  describe '#path' do
+    it { expect(described_class.path).to eq('/im/account/consumer') }
+  end
+end


### PR DESCRIPTION
## Motivation and Context
We need to be able to send Consumer KYC request via API.

## Description
<!--- Describe what you have done and why have you done it this way -->
1. Decreased the `httparty` gem because o our dependencies. 
2. Added Consumer Entity integration
3 Added tests for Consumer.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/998642/59200577-dbc63280-8b98-11e9-9183-55ad869ea0fd.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried to use it in the console
```
IdentityMind::Account::Consumer.create(params)
IdentityMind::Account::Consumer.fetch(transaction_id)
```